### PR TITLE
Add: Support for eza

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Other zsh plugin managers should work like `zplug`. If `fuzzy-fs` doesn't work w
 
 - [z](https://github.com/rupa/z "z") (to list recent files, you don't need autojump if you have z)
 - [autojump](https://github.com/wting/autojump "autojump") (to list recent files, you don't need z if you have autojump)
-- [exa](https://github.com/ogham/exa "exa") (to show colorful file list with git information)
+- [exa](https://github.com/ogham/exa "exa")/[eza](https://github.com/eza-community/eza "eza") (to show colorful file list with git information)
 - [bat](https://github.com/sharkdp/bat "bat") (for colored preview)
 - [fd](https://github.com/sharkdp/fd "fd") (for faster and colored find)
 
@@ -66,12 +66,12 @@ If you are not in a tmux session, the new shell will be opened in a new terminal
 
 ## Customizable Commands
 
-Maybe you don't like some commands used in `fuzzy-fs`. For example, maybe you prefer `ls` to `exa`. Here are some customizable commands.
+Maybe you don't like some commands used in `fuzzy-fs`. For example, maybe you prefer `ls` to `exa`/`eza`. Here are some customizable commands.
 
 | variable name             | meaning                            | default value       | Notes                                                                                |
 |---------------------------|------------------------------------|---------------------|--------------------------------------------------------------------------------------|
 | FUZZY_FS_OPEN_COMMAND     | the command to open a file         | `xdg-open`          |                                                                                      |
-| FUZZY_FS_LS_COMMAND       | the command to list files          | `exa` or `ls`       | only `exa` and `ls` are supported                                                    |
+| FUZZY_FS_LS_COMMAND       | the command to list files          | `exa`/`eza` or `ls`       | only `exa`/`eza` and `ls` are supported                                                    |
 | FUZZY_FS_TERMINAL_COMMAND | the command to open a new terminal | `konsole --workdir` | read the manual of your terminal emulator to know how to specify a working directory |
 
 ## Icons

--- a/fuzzy-fs
+++ b/fuzzy-fs
@@ -40,7 +40,7 @@ Options:
     -a    --all          list hidden files
     -H    --no-header    don't show key-binding tips in header
           --no-color     disable color
-    -g    --git          show git info in the file list (requires exa)
+    -g    --git          show git info in the file list (requires exa/eza)
     -d    --debug-mode   output debug info into log file
     -V    --version      show version
     -h    --help         show this help
@@ -71,7 +71,7 @@ EOF
     # tunable commands
     local open_command=${FUZZY_FS_OPEN_COMMAND:-xdg-open}
     local preview_command=${FUZZY_FS_PREVIEW_COMMAND:-$base_dir/module/_fuzzy-fs-preview}
-    local ls_command=${FUZZY_FS_LS_COMMAND:-$(_fuzzy-fs-first-available-command exa ls)}
+    local ls_command=${FUZZY_FS_LS_COMMAND:-$(_fuzzy-fs-first-available-command exa eza ls)}
     local terminal_command=${FUZZY_FS_TERMINAL_COMMAND:-$(_fuzzy-fs-first-available-command "konsole --workdir" "gnome-terminal --working-directory" "terminology -d")}
     export ls_command
 

--- a/module/_fuzzy-fs-preview
+++ b/module/_fuzzy-fs-preview
@@ -13,6 +13,8 @@ if [[ -d "$target" ]]; then
     echo
     if [[ "$ls_command" = exa ]]; then
         exa -la $color_param "$target"
+    elif [[ "$ls_command" = eza ]]; then
+        eza -la $color_param "$target"
     else
         ls -la $color_param "$target"
     fi

--- a/module/ls/_fuzzy-fs-list-file
+++ b/module/ls/_fuzzy-fs-list-file
@@ -10,7 +10,7 @@ function _fuzzy-fs-list-file {
     local color_param=""
     local shown_hidden=""
     case $ls_command in
-        exa)
+        exa | eza)
             params="-lh"
             if [[ ! -z "$show_git" ]]; then
                 params+=" --git"
@@ -43,7 +43,7 @@ function _fuzzy-fs-list-file {
 
     # count the column number to know which column is filename
     case $ls_command in
-        exa) filename_column=$(($(echo $header | wc -w)+1)) ;;
+        exa | eza) filename_column=$(($(echo $header | wc -w)+1)) ;;
         ls) filename_column=9 ;;
     esac
 


### PR DESCRIPTION
- There is already support for "exa" as an alternative to ls when listing files
- The repo for exa is unmaintained and the owner recommends using the forked project "eza" instead, which is found at github.com/eza-community/eza